### PR TITLE
Свой путь к конфигу и хранение заголовков ответа

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -15,13 +15,11 @@ class Handler
     public $result;
     public $last_insert_id;
 
-    public function __construct($domain = null, $user = null, $debug = false)
+    public function __construct($domain = null, $user = null, $debug = false, $config_dir = __DIR__ . '/../config/')
     {
         $this->domain = $domain;
         $this->user = $user;
         $this->debug = $debug;
-
-        $config_dir = __DIR__ . '/../config/';
 
         $file_key = $config_dir . $this->domain . '@' . $this->user . '.key';
         $file_config = $config_dir . 'config@' . $this->domain . '.php';
@@ -50,7 +48,7 @@ class Handler
         }
 
         if ($this->debug) {
-            $this->errors = @json_decode(trim(file_get_contents($config_dir . 'errors.json')));
+            $this->errors = @json_decode(trim(file_get_contents(__DIR__ . '/../config/errors.json')));
         }
 
         $this->key = $key;

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -2,11 +2,14 @@
 
 namespace AmoCRM;
 
+use http\Env\Response;
+
 class Handler
 {
     private $domain;
     private $debug;
     private $errors;
+    private $pathLog;
 
     public $user;
     public $key;
@@ -15,12 +18,13 @@ class Handler
     public $result;
     public $last_insert_id;
 
-    public function __construct($domain = null, $user = null, $key, $debug = false)
+    public function __construct($domain = null, $user = null, $key, $debug = false, $pathLog = '')
     {
         $this->domain = $domain;
         $this->user = $user;
         $this->key = $key;
         $this->debug = $debug;
+        $this->pathLog = $pathLog;
 
         if (empty($key)) {
             throw new \Exception('Api ключ не указан');
@@ -76,6 +80,17 @@ class Handler
         $info = curl_getinfo($ch);
         $error = curl_error($ch);
 
+        if (0) {
+            if ($request->object == null) {
+                $pathLog = $this->pathLog . $request->request_type . '.json';
+            } elseif(isset($request->params['limit_offset'])) {
+                $pathLog = $this->pathLog . $request->object[0] . '_' . $request->object[1] .'_' . $request->params['limit_offset'] .'.json';
+            } else {
+                $pathLog = $this->pathLog . $request->object[0] . '_' . $request->object[1].'.json';
+            }
+            file_put_contents($pathLog, $result);
+        }
+
         curl_close($ch);
 
         if ($error) {
@@ -83,8 +98,46 @@ class Handler
         }
 
         $this->headers_response = $headers_response;
-        $this->result = json_decode($result);
+        $this->result = json_decode($result, $request->format);
 
+        if ($request->format == Request::FORMAT_ARRAY) {
+            return $this->parseArray($request, $info);
+        }
+
+        return $this->parseObject($request, $info);
+    }
+
+    public function parseArray($request, $info)
+    {
+        if (floor($info['http_code'] / 100) >= 3) {
+            if (!$this->debug) {
+                $message = $this->result['response']['error'];
+            } else {
+                $error = (isset($this->result['response']['error'])) ? $this->result['response']['error'] : '';
+                $error_code = (isset($this->result['response']['error_code'])) ? $this->result['response']['error_code'] : '';
+                $description = ($error && $error_code && isset($this->errors[$error_code])) ? $this->errors[$error_code] : '';
+                $response = (isset($this->result['response']['error'])) ? $this->result['response']['error'] : '';
+
+                $message = json_encode([
+                    'http_code' => $info['http_code'],
+                    'response' => $response,
+                    'description' => $description
+                ], JSON_UNESCAPED_UNICODE);
+            }
+
+            throw new \Exception($message);
+        }
+
+        $this->result = isset($this->result['response']) ? $this->result['response'] : false;
+        $this->last_insert_id = ($request->post && isset($this->result[$request->type][$request->action][0]->id))
+            ? $this->result[$request->type][$request->action][0]->id
+            : false;
+
+        return $this;
+    }
+
+    public function parseObject($request, $info)
+    {
         if (floor($info['http_code'] / 100) >= 3) {
             if (!$this->debug) {
                 $message = $this->result->response->error;

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -100,6 +100,10 @@ class Handler
         $this->headers_response = $headers_response;
         $this->result = json_decode($result, $request->format);
 
+        if (json_last_error() != JSON_ERROR_NONE) {
+            return $this;
+        }
+
         if ($request->format == Request::FORMAT_ARRAY) {
             return $this->parseArray($request, $info);
         }

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -10,49 +10,21 @@ class Handler
 
     public $user;
     public $key;
-    public $config;
+    public $config = [];
     public $headers_response;
     public $result;
     public $last_insert_id;
 
-    public function __construct($domain = null, $user = null, $debug = false, $config_dir = __DIR__ . '/../config/')
+    public function __construct($domain = null, $user = null, $key, $debug = false)
     {
         $this->domain = $domain;
         $this->user = $user;
+        $this->key = $key;
         $this->debug = $debug;
 
-        $file_key = $config_dir . $this->domain . '@' . $this->user . '.key';
-        $file_config = $config_dir . 'config@' . $this->domain . '.php';
-
-        if (!is_readable($config_dir) || !is_writable($config_dir)) {
-            throw new \Exception('Директория "config" должна быть доступна для чтения и записи');
-        }
-
-        if (!file_exists($file_key)) {
-            throw new \Exception('Отсутсвует файл с ключом');
-        }
-
-        if (!file_exists($file_config)) {
-            throw new \Exception('Отсутсвует файл с конфигурацией');
-        }
-
-        $key = trim(file_get_contents($file_key));
-        $config = trim(file_get_contents($file_config));
-
         if (empty($key)) {
-            throw new \Exception('Файл с ключом пуст');
+            throw new \Exception('Api ключ не указан');
         }
-
-        if (empty($config)) {
-            throw new \Exception('Файл с конфигурацией пуст');
-        }
-
-        if ($this->debug) {
-            $this->errors = @json_decode(trim(file_get_contents(__DIR__ . '/../config/errors.json')));
-        }
-
-        $this->key = $key;
-        $this->config = include $file_config;
 
         $this->request(new Request(Request::AUTH, $this));
     }
@@ -72,8 +44,8 @@ class Handler
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
-        curl_setopt($ch, CURLOPT_COOKIEFILE, __DIR__ . '/../config/cookie.txt');
-        curl_setopt($ch, CURLOPT_COOKIEJAR, __DIR__ . '/../config/cookie.txt');
+        curl_setopt($ch, CURLOPT_COOKIEFILE, __DIR__ . '/../config/cookie_' . $this->key . '.txt');
+        curl_setopt($ch, CURLOPT_COOKIEJAR, __DIR__ . '/../config/cookie_' . $this->key . '.txt');
 
         curl_setopt($ch, CURLOPT_HEADERFUNCTION,
             function($curl, $header) use (&$headers_response)

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -43,6 +43,7 @@ class Handler
         curl_setopt($ch, CURLOPT_USERAGENT, 'amoCRM-API-client/1.0');
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
         curl_setopt($ch, CURLOPT_COOKIEFILE, __DIR__ . '/../config/cookie_' . $this->key . '.txt');

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -36,9 +36,10 @@ class Handler
         if ($date = $request->getIfModifiedSince()) {
             $headers[] = 'IF-MODIFIED-SINCE: ' . $date;
         }
+        $headers[] = 'X-Requested-With: XMLHttpRequest';
 
         $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, 'https://' . $this->domain . '.amocrm.ru/private/api/' . $request->url);
+        curl_setopt($ch, CURLOPT_URL, 'https://' . $this->domain . '.amocrm.ru' . $request->url);
         curl_setopt($ch, CURLOPT_USERAGENT, 'amoCRM-API-client/1.0');
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/src/Request.php
+++ b/src/Request.php
@@ -10,20 +10,27 @@ class Request
     const SET = 4;
     const GOALS = 5;
 
+    const FORMAT_ARRAY = true;
+    const FORMAT_OBJECT = false;
+
+    public $request_type;
     public $post;
     public $url;
     public $type;
     public $action;
     public $params;
+    public $format;
 
     private $if_modified_since;
-    private $object;
+    public $object;
 
     public function __construct($request_type = null, $params = null, $object = null)
     {
+        $this->request_type = $request_type;
         $this->post = false;
         $this->params = $params;
         $this->object = $object;
+        $this->format = self::FORMAT_OBJECT;
 
         switch ($request_type) {
             case Request::AUTH:
@@ -43,6 +50,11 @@ class Request
                 $this->createGetGoals();
                 break;
         }
+    }
+
+    public function setFormat($format)
+    {
+        $this->format = $format;
     }
 
     public function setIfModifiedSince($if_modified_since)
@@ -75,7 +87,7 @@ class Request
 
     private function createInfoRequest()
     {
-        $this->url = '/private/api/v2/json/accounts/current';
+        $this->url = '/private/api/v2/json/accounts/current?with=users&free_users=Y';
     }
 
     private function createGetRequest()

--- a/src/Request.php
+++ b/src/Request.php
@@ -8,6 +8,7 @@ class Request
     const INFO = 2;
     const GET = 3;
     const SET = 4;
+    const GOALS = 5;
 
     public $post;
     public $url;
@@ -37,6 +38,10 @@ class Request
             case Request::SET:
                 $this->createPostRequest();
                 break;
+
+            case Request::GOALS:
+                $this->createGetGoals();
+                break;
         }
     }
 
@@ -50,10 +55,17 @@ class Request
         return empty($this->if_modified_since) ? false : $this->if_modified_since;
     }
 
+    private function createGetGoals()
+    {
+        //https://lookvokrug.amocrm.ru/ajax/stats/goals/settings/
+        $this->post = true;
+        $this->url = '/ajax/stats/goals/settings/';
+    }
+
     private function createAuthRequest()
     {
         $this->post = true;
-        $this->url = 'auth.php?type=json';
+        $this->url = '/private/api/auth.php?type=json';
 
         $this->params = [
             'USER_LOGIN' => $this->params->user,
@@ -63,12 +75,12 @@ class Request
 
     private function createInfoRequest()
     {
-        $this->url = 'v2/json/accounts/current';
+        $this->url = '/private/api/v2/json/accounts/current';
     }
 
     private function createGetRequest()
     {
-        $this->url = 'v2/json/' . $this->object[0] . '/' . $this->object[1];
+        $this->url = '/private/api/v2/json/' . $this->object[0] . '/' . $this->object[1];
         $this->url .= (count($this->params) ? '?' . http_build_query($this->params) : '');
     }
 
@@ -89,7 +101,7 @@ class Request
         $this->post = true;
         $this->type = $key_name;
         $this->action = $action;
-        $this->url = 'v2/json/' . $url_name . '/set';
+        $this->url = '/private/api/v2/json/' . $url_name . '/set';
         $this->params = $params;
     }
 }


### PR DESCRIPTION
1. Добавлена возможность указать свою папку config
`$api = new Handler('subdomain', 'user', false, 'config/');`

2. в handler.php добавлено хранение заголовков ответа, получить можно так
```
$request_get = new Request(Request::GET, [], ['leads', 'list']);
$result = $api->request($request_get);
print_r($result->headers_response['date'][0]);
print_r($result->result);
```

